### PR TITLE
[Forwardport] Improvement: Magento\Sales\Helper\Guest refactoring and bugfix

### DIFF
--- a/app/code/Magento/Sales/Helper/Guest.php
+++ b/app/code/Magento/Sales/Helper/Guest.php
@@ -83,7 +83,7 @@ class Guest extends \Magento\Framework\App\Helper\AbstractHelper
     /**
      * @var \Magento\Store\Model\StoreManagerInterface
      */
-    private $_storeManager;
+    private $storeManager;
 
     /**
      * @var string
@@ -119,7 +119,7 @@ class Guest extends \Magento\Framework\App\Helper\AbstractHelper
         \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteria = null
     ) {
         $this->coreRegistry = $coreRegistry;
-        $this->_storeManager = $storeManager;
+        $this->storeManager = $storeManager;
         $this->customerSession = $customerSession;
         $this->cookieManager = $cookieManager;
         $this->cookieMetadataFactory = $cookieMetadataFactory;
@@ -158,9 +158,10 @@ class Guest extends \Magento\Framework\App\Helper\AbstractHelper
         // It is unique place in the class that process exception and only InputException. It is need because by
         // input data we found order and one more InputException could be throws deeper in stack trace
         try {
-            $order = (!empty($post) && isset($post['oar_order_id'], $post['oar_type']))
+            $order = (!empty($post)
+                && isset($post['oar_order_id'], $post['oar_type'])
+                && !$this->hasPostDataEmptyFields($post))
                 ? $this->loadFromPost($post) : $this->loadFromCookie($fromCookie);
-            $this->validateOrderStoreId($order->getStoreId());
             $this->coreRegistry->register('current_order', $order);
             return true;
         } catch (InputException $e) {
@@ -186,7 +187,7 @@ class Guest extends \Magento\Framework\App\Helper\AbstractHelper
             [
                 'label' => __('Home'),
                 'title' => __('Go to Home Page'),
-                'link' => $this->_storeManager->getStore()->getBaseUrl()
+                'link' => $this->storeManager->getStore()->getBaseUrl()
             ]
         );
         $breadcrumbs->addCrumb(
@@ -216,7 +217,7 @@ class Guest extends \Magento\Framework\App\Helper\AbstractHelper
      * Load order from cookie
      *
      * @param string $fromCookie
-     * @return Order
+     * @return \Magento\Sales\Model\Order\Interceptor
      * @throws InputException
      * @throws CookieSizeLimitReachedException
      * @throws FailureToSendException
@@ -240,19 +241,16 @@ class Guest extends \Magento\Framework\App\Helper\AbstractHelper
      * Load order data from post
      *
      * @param array $postData
-     * @return Order
+     * @return \Magento\Sales\Model\Order\Interceptor
      * @throws InputException
      * @throws CookieSizeLimitReachedException
      * @throws FailureToSendException
      */
     private function loadFromPost(array $postData)
     {
-        if ($this->hasPostDataEmptyFields($postData)) {
-            throw new InputException();
-        }
         /** @var $order \Magento\Sales\Model\Order */
         $order = $this->getOrderRecord($postData['oar_order_id']);
-        if (!$this->compareSoredBillingDataWithInput($order, $postData)) {
+        if (!$this->compareStoredBillingDataWithInput($order, $postData)) {
             throw new InputException(__('You entered incorrect data. Please try again.'));
         }
         $toCookie = base64_encode($order->getProtectCode() . ':' . $postData['oar_order_id']);
@@ -267,7 +265,7 @@ class Guest extends \Magento\Framework\App\Helper\AbstractHelper
      * @param array $postData
      * @return bool
      */
-    private function compareSoredBillingDataWithInput(Order $order, array $postData)
+    private function compareStoredBillingDataWithInput(Order $order, array $postData)
     {
         $type = $postData['oar_type'];
         $email = $postData['oar_email'];
@@ -288,7 +286,7 @@ class Guest extends \Magento\Framework\App\Helper\AbstractHelper
     private function hasPostDataEmptyFields(array $postData)
     {
         return empty($postData['oar_order_id']) || empty($postData['oar_billing_lastname']) ||
-            empty($postData['oar_type']) || empty($this->_storeManager->getStore()->getId()) ||
+            empty($postData['oar_type']) || empty($this->storeManager->getStore()->getId()) ||
             !in_array($postData['oar_type'], ['email', 'zip'], true) ||
             ('email' === $postData['oar_type'] && empty($postData['oar_email'])) ||
             ('zip' === $postData['oar_type'] && empty($postData['oar_zip']));
@@ -298,7 +296,7 @@ class Guest extends \Magento\Framework\App\Helper\AbstractHelper
      * Get order by increment_id and store_id
      *
      * @param string $incrementId
-     * @return \Magento\Sales\Api\Data\OrderInterface
+     * @return array
      * @throws InputException
      */
     private function getOrderRecord($incrementId)
@@ -306,26 +304,15 @@ class Guest extends \Magento\Framework\App\Helper\AbstractHelper
         $records = $this->orderRepository->getList(
             $this->searchCriteriaBuilder
                 ->addFilter('increment_id', $incrementId)
+                ->addFilter('store_id', $this->storeManager->getStore()->getId())
                 ->create()
         );
-        if ($records->getTotalCount() < 1) {
-            throw new InputException(__($this->inputExceptionMessage));
-        }
-        $items = $records->getItems();
-        return array_shift($items);
-    }
 
-    /**
-     * Check that store_id from order are equals with system
-     *
-     * @param int $orderStoreId
-     * @return void
-     * @throws InputException
-     */
-    private function validateOrderStoreId($orderStoreId)
-    {
-        if ($orderStoreId != $this->_storeManager->getStore()->getId()) {
+        $items = $records->getItems();
+        if (empty($items)) {
             throw new InputException(__($this->inputExceptionMessage));
         }
+
+        return array_shift($items);
     }
 }

--- a/app/code/Magento/Sales/Helper/Guest.php
+++ b/app/code/Magento/Sales/Helper/Guest.php
@@ -217,7 +217,7 @@ class Guest extends \Magento\Framework\App\Helper\AbstractHelper
      * Load order from cookie
      *
      * @param string $fromCookie
-     * @return \Magento\Sales\Model\Order\Interceptor
+     * @return Order
      * @throws InputException
      * @throws CookieSizeLimitReachedException
      * @throws FailureToSendException
@@ -241,7 +241,7 @@ class Guest extends \Magento\Framework\App\Helper\AbstractHelper
      * Load order data from post
      *
      * @param array $postData
-     * @return \Magento\Sales\Model\Order\Interceptor
+     * @return Order
      * @throws InputException
      * @throws CookieSizeLimitReachedException
      * @throws FailureToSendException
@@ -296,7 +296,7 @@ class Guest extends \Magento\Framework\App\Helper\AbstractHelper
      * Get order by increment_id and store_id
      *
      * @param string $incrementId
-     * @return array
+     * @return \Magento\Sales\Api\Data\OrderInterface
      * @throws InputException
      */
     private function getOrderRecord($incrementId)


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/12893
Dear Magento2,

This PR consists of several improvements and bug fixes. The main goal of it is to increase performance and logic side of the Magento\Sales\Helper\Guest. Please, review Description section for more information.

Looking forward to your reply,
Alex

### Description
The main improvements here are in the `Magento\Sales\Helper\Guest::getOrderRecord($incrementId)`  

1. Added `store_id` as filter to search criteria to improve logic/performance and due to this fact the `Magento\Sales\Helper\Guest::validateOrderStoreId($orderStoreId)` can be removed.

1. Replaced
```
        if ($records->getTotalCount() < 1) {
            throw new InputException(__($this->inputExceptionMessage));
        }
        $items = $records->getItems();
        return array_shift($items);
```
with
```
        $items = $records->getItems();
        if (empty($items)) {
            throw new InputException(__($this->inputExceptionMessage));
        }

        return array_shift($items);
```
This allows Magento to reduce the number of database queries because every time when the `getTotalCount()` is called it initiates the `getSize()` method which checks the `$this->_totalRecords` value but in this case it equals to `null` every new call because every new call begins after page load.

3. Moved `$this->hasPostDataEmptyFields($post)` to ternary operator because this is good to have all conditions according to order in one place.

4. Fixed typo `compareSoredBillingDataWithInput` to `compareStoredBillingDataWithInput`

5. Removed underscore `private $_storeManager;` to `private $storeManager;` (PSR-2: Property names SHOULD NOT be prefixed with a single underscore to indicate protected or private visibility.)

### Fixed Issues (if relevant)
No relevant issue.

### Manual testing scenarios
Those changes didn't change business logic. Only code improvement and, as a result, no manual testing scenarios.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
