### PR TITLE
[Forwardport] Added language translation, make proper sentence and removed unused delete html container

### DIFF
--- a/app/code/Magento/Integration/i18n/en_US.csv
+++ b/app/code/Magento/Integration/i18n/en_US.csv
@@ -93,7 +93,7 @@ Reset,Reset
 "A token with consumer ID 0 does not exist","A token with consumer ID 0 does not exist"
 "The integration you selected asks you to approve access to the following:","The integration you selected asks you to approve access to the following:"
 "No permissions requested","No permissions requested"
-"Are you sure ?","Are you sure ?"
+"Are you sure?","Are you sure?"
 "Are you sure you want to delete this integration? You can't undo this action.","Are you sure you want to delete this integration? You can't undo this action."
 "Please setup or sign in into your 3rd party account to complete setup of this integration.","Please setup or sign in into your 3rd party account to complete setup of this integration."
 "Available APIs","Available APIs"

--- a/app/code/Magento/Integration/view/adminhtml/templates/integration/popup_container.phtml
+++ b/app/code/Magento/Integration/view/adminhtml/templates/integration/popup_container.phtml
@@ -33,8 +33,8 @@
             $('div#integrationGrid').on('click', 'button#delete', function (e) {
 
                 new Confirm({
-                    title: 'Are you sure?',
-                    content: "Are you sure you want to delete this integration? You can't undo this action.",
+                    title: '<?= /* @escapeNotVerified */ __('Are you sure?') ?>',
+                    content: "<?= /* @escapeNotVerified */ __("Are you sure you want to delete this integration? You can't undo this action.") ?>",
                     actions: {
                         confirm: function () {
                             window.location.href = $(e.target).data('url');

--- a/app/code/Magento/Integration/view/adminhtml/templates/integration/popup_container.phtml
+++ b/app/code/Magento/Integration/view/adminhtml/templates/integration/popup_container.phtml
@@ -48,13 +48,3 @@
 </script>
 
 <div id="integration-popup-container" style="display: none;"></div>
-<div id="integration-delete-container"
-     class="messages"
-     style="display: none;"
-     title="<?= /* @escapeNotVerified */ __('Are you sure?') ?>">
-    <div class="message message-notice notice">
-        <div>
-            <?= /* @escapeNotVerified */ __("Are you sure you want to delete this integration? You can't undo this action.") ?>
-        </div>
-    </div>
-</div>

--- a/app/code/Magento/Integration/view/adminhtml/templates/integration/popup_container.phtml
+++ b/app/code/Magento/Integration/view/adminhtml/templates/integration/popup_container.phtml
@@ -51,7 +51,7 @@
 <div id="integration-delete-container"
      class="messages"
      style="display: none;"
-     title="<?= /* @escapeNotVerified */ __('Are you sure ?') ?>">
+     title="<?= /* @escapeNotVerified */ __('Are you sure?') ?>">
     <div class="message message-notice notice">
         <div>
             <?= /* @escapeNotVerified */ __("Are you sure you want to delete this integration? You can't undo this action.") ?>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14308
Added language translation for two message appears inside modal popup on click delete icon of integration. (Goto: SYSTEM > Extensions > Integrations)

Delete confirm box appears on triggering click event of delete icon at integration grid through Confirm (Magento_Ui/js/modal/confirm) javascript class.

Delete confirm box appears through Confirm class so there is no use of #integration-delete-container HTML block

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. ...
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
