### PR TITLE
[Forwardport] Moved Google Analytics block code to head tag #8837

### DIFF
--- a/app/code/Magento/GoogleAnalytics/etc/adminhtml/system.xml
+++ b/app/code/Magento/GoogleAnalytics/etc/adminhtml/system.xml
@@ -23,11 +23,10 @@
                         <field id="*/*/active">1</field>
                     </depends>
                 </field>
-
-		<field id="anonymize" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="anonymize" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Anonymize IP</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-		    <depends>
+                    <depends>
                         <field id="*/*/active">1</field>
                     </depends>
                 </field>

--- a/app/code/Magento/GoogleAnalytics/view/frontend/layout/default.xml
+++ b/app/code/Magento/GoogleAnalytics/view/frontend/layout/default.xml
@@ -7,7 +7,7 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <referenceContainer name="after.body.start">
+        <referenceContainer name="head.additional">
             <block class="Magento\GoogleAnalytics\Block\Ga" name="google_analytics" as="google_analytics" template="Magento_GoogleAnalytics::ga.phtml"/>
         </referenceContainer>
     </body>

--- a/dev/tests/integration/testsuite/Magento/GoogleAnalytics/Block/GaTest.php
+++ b/dev/tests/integration/testsuite/Magento/GoogleAnalytics/Block/GaTest.php
@@ -4,6 +4,8 @@
  * See COPYING.txt for license details.
  */
 
+declare(strict_types=1);
+
 namespace Magento\GoogleAnalytics\Block;
 
 use Magento\TestFramework\TestCase\AbstractController;

--- a/dev/tests/integration/testsuite/Magento/GoogleAnalytics/Block/GaTest.php
+++ b/dev/tests/integration/testsuite/Magento/GoogleAnalytics/Block/GaTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\GoogleAnalytics\Block;
+
+use Magento\Framework\App\ObjectManager;
+use Magento\TestFramework\TestCase\AbstractController;
+
+class GaTest extends AbstractController
+{
+    /**
+     * Layout instance
+     *
+     * @var \Magento\Framework\View\LayoutInterface
+     */
+    private $layout;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->dispatch('/');
+        $this->layout = ObjectManager::getInstance()->get(
+            \Magento\Framework\View\LayoutInterface::class
+        );
+    }
+
+    /**
+     * Check for correct position of GA block
+     */
+    public function testBlockPresentInHead()
+    {
+        $this->assertNotNull(
+            $this->getGaBlockFromNode('head.additional')
+        );
+    }
+
+    /**
+     * Test that block has been successfully moved
+     * from body to head tag.
+     */
+    public function testBlockIsAbsentInBody()
+    {
+        $this->assertFalse(
+            $this->getGaBlockFromNode('after.body.start')
+        );
+    }
+
+    /**
+     * Test null output when GA is disabled
+     *
+     * @magentoAppArea frontend
+     * @magentoConfigFixture current_store google/analytics/active 0
+     * @magentoConfigFixture current_store google/analytics/account XXXXXXX
+     */
+    public function testBlockOutputIsEmptyWhenGaIsDisabled()
+    {
+        $this->assertEquals(
+            "",
+            $this->getGaBlockFromNode('head.additional')->toHtml()
+        );
+    }
+
+    /**
+     * Check, that block successfully gets rendered when configuration is
+     * active.
+     *
+     * @magentoAppArea frontend
+     * @magentoConfigFixture current_store google/analytics/active 1
+     * @magentoConfigFixture current_store google/analytics/account XXXXXXX
+     */
+    public function testBlockOutputExistsWhenGaIsEnabled()
+    {
+        $this->assertNotEquals(
+            "",
+            $this->getGaBlockFromNode('head.additional')->toHtml()
+        );
+    }
+
+    /**
+     * Get GA block
+     *
+     * @param string $nodeName
+     * @return \Magento\Framework\View\Element\AbstractBlock|false
+     */
+    private function getGaBlockFromNode($nodeName = 'head.additional')
+    {
+        return $this->layout->getChildBlock($nodeName, 'google_analytics');
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/GoogleAnalytics/Block/GaTest.php
+++ b/dev/tests/integration/testsuite/Magento/GoogleAnalytics/Block/GaTest.php
@@ -6,7 +6,6 @@
 
 namespace Magento\GoogleAnalytics\Block;
 
-use Magento\Framework\App\ObjectManager;
 use Magento\TestFramework\TestCase\AbstractController;
 
 class GaTest extends AbstractController
@@ -25,9 +24,7 @@ class GaTest extends AbstractController
     {
         parent::setUp();
         $this->dispatch('/');
-        $this->layout = ObjectManager::getInstance()->get(
-            \Magento\Framework\View\LayoutInterface::class
-        );
+        $this->layout = $this->_objectManager->get(\Magento\Framework\View\LayoutInterface::class);
     }
 
     /**
@@ -90,6 +87,12 @@ class GaTest extends AbstractController
      */
     private function getGaBlockFromNode($nodeName = 'head.additional')
     {
-        return $this->layout->getChildBlock($nodeName, 'google_analytics');
+        $childBlocks = $this->layout->getChildBlocks($nodeName);
+        foreach ($childBlocks as $block) {
+            if (strpos($block->getNameInLayout(), 'google_analytics') !== false) {
+                return $block;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14293
### Description
Moved Google Analytics block to head tag.

### Fixed Issues (if relevant)
https://github.com/magento/magento2/issues/8837 - Google Analytics code being placed in body instead of head.

### Manual testing scenarios
1. Enable Google Analytics in Magento by going to Stores->Configuration->Sales->Google API.
2. Put related variables.
3. See, that Google Analytics script is being generated in head tag.

### Tests
Added integration tests on Google Analytics block to ensure, that it has been moved.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
