### PR TITLE
[Forwardport] [Backport 2.2] Configurable product price options by store

### DIFF
--- a/app/code/Magento/Backend/Model/Widget/Grid/Parser.php
+++ b/app/code/Magento/Backend/Model/Widget/Grid/Parser.php
@@ -30,8 +30,8 @@ class Parser
         $expression = trim($expression);
         foreach ($this->_operations as $operation) {
             $splittedExpr = preg_split('/\\' . $operation . '/', $expression, -1, PREG_SPLIT_DELIM_CAPTURE);
-            if (!empty($splittedExpr)) {
-                $count = count($splittedExpr);
+            $count = count($splittedExpr);
+            if ($count > 1) {
                 for ($i = 0; $i < $count; $i++) {
                     $stack = array_merge($stack, $this->parseExpression($splittedExpr[$i]));
                     if ($i > 0) {

--- a/app/code/Magento/Backend/Model/Widget/Grid/Parser.php
+++ b/app/code/Magento/Backend/Model/Widget/Grid/Parser.php
@@ -30,8 +30,9 @@ class Parser
         $expression = trim($expression);
         foreach ($this->_operations as $operation) {
             $splittedExpr = preg_split('/\\' . $operation . '/', $expression, -1, PREG_SPLIT_DELIM_CAPTURE);
-            if (count($splittedExpr) > 1) {
-                for ($i = 0; $i < count($splittedExpr); $i++) {
+            if (!empty($splittedExpr)) {
+                $count = count($splittedExpr);
+                for ($i = 0; $i < $count; $i++) {
                     $stack = array_merge($stack, $this->parseExpression($splittedExpr[$i]));
                     if ($i > 0) {
                         $stack[] = $operation;

--- a/app/code/Magento/Catalog/Model/Api/SearchCriteria/CollectionProcessor/FilterProcessor/ProductCategoryFilter.php
+++ b/app/code/Magento/Catalog/Model/Api/SearchCriteria/CollectionProcessor/FilterProcessor/ProductCategoryFilter.php
@@ -21,7 +21,7 @@ class ProductCategoryFilter implements CustomFilterInterface
      */
     public function apply(Filter $filter, AbstractDb $collection)
     {
-        $conditionType = $filter->getConditionType() ? $filter->getConditionType() : 'eq';
+        $conditionType = $filter->getConditionType() ?: 'eq';
         $categoryFilter = [$conditionType => [$filter->getValue()]];
 
         /** @var Collection $collection */

--- a/app/code/Magento/Catalog/Model/CategoryRepository.php
+++ b/app/code/Magento/Catalog/Model/CategoryRepository.php
@@ -129,7 +129,7 @@ class CategoryRepository implements \Magento\Catalog\Api\CategoryRepositoryInter
      */
     public function get($categoryId, $storeId = null)
     {
-        $cacheKey = null !== $storeId ? $storeId : 'all';
+        $cacheKey = $storeId ?? 'all';
         if (!isset($this->instances[$categoryId][$cacheKey])) {
             /** @var Category $category */
             $category = $this->categoryFactory->create();

--- a/app/code/Magento/Catalog/Model/Layer/Filter/DataProvider/Price.php
+++ b/app/code/Magento/Catalog/Model/Layer/Filter/DataProvider/Price.php
@@ -282,7 +282,8 @@ class Price
     public function getPriorFilters($filterParams)
     {
         $priorFilters = [];
-        for ($i = 1; $i < count($filterParams); ++$i) {
+        $count = count($filterParams);
+        for ($i = 1; $i < $count; ++$i) {
             $priorFilter = $this->validateFilter($filterParams[$i]);
             if ($priorFilter) {
                 $priorFilters[] = $priorFilter;

--- a/app/code/Magento/Catalog/Model/Product.php
+++ b/app/code/Magento/Catalog/Model/Product.php
@@ -2006,7 +2006,7 @@ class Product extends \Magento\Catalog\Model\AbstractModel implements
      */
     public function addCustomOption($code, $value, $product = null)
     {
-        $product = $product ? $product : $this;
+        $product = $product ?: $this;
         $option = $this->_itemOptionFactory->create()->addData(
             ['product_id' => $product->getId(), 'product' => $product, 'code' => $code, 'value' => $value]
         );

--- a/app/code/Magento/Catalog/Model/Product/Option/Type/File.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Type/File.php
@@ -127,7 +127,7 @@ class File extends \Magento\Catalog\Model\Product\Option\Type\DefaultType
         $this->mediaDirectory = $this->filesystem->getDirectoryWrite(DirectoryList::MEDIA);
         $this->validatorInfo = $validatorInfo;
         $this->validatorFile = $validatorFile;
-        $this->serializer = $serializer ? $serializer : ObjectManager::getInstance()->get(Json::class);
+        $this->serializer = $serializer ?: ObjectManager::getInstance()->get(Json::class);
         parent::__construct($checkoutSession, $scopeConfig, $data);
     }
 

--- a/app/code/Magento/Catalog/Model/Product/ProductList/Toolbar.php
+++ b/app/code/Magento/Catalog/Model/Product/ProductList/Toolbar.php
@@ -102,6 +102,6 @@ class Toolbar
     public function getCurrentPage()
     {
         $page = (int) $this->request->getParam(self::PAGE_PARM_NAME);
-        return $page ? $page : 1;
+        return $page ?: 1;
     }
 }

--- a/app/code/Magento/Catalog/Model/Product/Type/Price.php
+++ b/app/code/Magento/Catalog/Model/Product/Type/Price.php
@@ -341,7 +341,7 @@ class Price
             }
         }
 
-        return $prices ? $prices : [];
+        return $prices ?: [];
     }
 
     /**

--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -740,7 +740,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         $fields = [];
         $categoryFilter = [];
         foreach ($filterGroup->getFilters() as $filter) {
-            $conditionType = $filter->getConditionType() ? $filter->getConditionType() : 'eq';
+            $conditionType = $filter->getConditionType() ?: 'eq';
 
             if ($filter->getField() == 'category_id') {
                 $categoryFilter[$conditionType][] = $filter->getValue();

--- a/app/code/Magento/Catalog/Test/Unit/Model/Api/SearchCriteria/CollectionProcessor/FilterProcessor/ProductCategoryFilterTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Api/SearchCriteria/CollectionProcessor/FilterProcessor/ProductCategoryFilterTest.php
@@ -31,7 +31,7 @@ class ProductCategoryFilterTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $filterMock->expects($this->exactly(2))
+        $filterMock->expects($this->exactly(1))
             ->method('getConditionType')
             ->willReturn('condition');
         $filterMock->expects($this->once())

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Structure/Element/Dependency/MapperTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Structure/Element/Dependency/MapperTest.php
@@ -98,7 +98,8 @@ class MapperTest extends \PHPUnit\Framework\TestCase
     {
         $expected = [];
         $rowData = array_values($this->_testData);
-        for ($i = 0; $i < count($this->_testData); ++$i) {
+        $count = $this->_testData;
+        for ($i = 0; $i < $count; ++$i) {
             $data = $rowData[$i];
             $dependentPath = 'some path ' . $i;
             $field = $this->_getField(
@@ -158,7 +159,8 @@ class MapperTest extends \PHPUnit\Framework\TestCase
     {
         $expected = [];
         $rowData = array_values($this->_testData);
-        for ($i = 0; $i < count($this->_testData); ++$i) {
+        $count = count($this->_testData);
+        for ($i = 0; $i < $count; ++$i) {
             $data = $rowData[$i];
             $field = $this->_getField(
                 true,

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Structure/Element/Dependency/MapperTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Structure/Element/Dependency/MapperTest.php
@@ -98,7 +98,7 @@ class MapperTest extends \PHPUnit\Framework\TestCase
     {
         $expected = [];
         $rowData = array_values($this->_testData);
-        $count = $this->_testData;
+        $count = count($this->_testData);
         for ($i = 0; $i < $count; ++$i) {
             $data = $rowData[$i];
             $dependentPath = 'some path ' . $i;

--- a/app/code/Magento/ConfigurableProduct/Pricing/Price/LowestPriceOptionsProvider.php
+++ b/app/code/Magento/ConfigurableProduct/Pricing/Price/LowestPriceOptionsProvider.php
@@ -9,6 +9,8 @@ use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\ResourceModel\Product\LinkedProductSelectBuilderInterface;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Retrieve list of products where each product contains lower price than others at least for one possible price type
@@ -31,7 +33,12 @@ class LowestPriceOptionsProvider implements LowestPriceOptionsProviderInterface
     private $collectionFactory;
 
     /**
-     * Key is product id. Value is array of prepared linked products
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * Key is product id and store id. Value is array of prepared linked products
      *
      * @var array
      */
@@ -41,15 +48,19 @@ class LowestPriceOptionsProvider implements LowestPriceOptionsProviderInterface
      * @param ResourceConnection $resourceConnection
      * @param LinkedProductSelectBuilderInterface $linkedProductSelectBuilder
      * @param CollectionFactory $collectionFactory
+     * @param StoreManagerInterface $storeManager
      */
     public function __construct(
         ResourceConnection $resourceConnection,
         LinkedProductSelectBuilderInterface $linkedProductSelectBuilder,
-        CollectionFactory $collectionFactory
+        CollectionFactory $collectionFactory,
+        StoreManagerInterface $storeManager = null
     ) {
         $this->resource = $resourceConnection;
         $this->linkedProductSelectBuilder = $linkedProductSelectBuilder;
         $this->collectionFactory = $collectionFactory;
+        $this->storeManager = $storeManager
+            ?: ObjectManager::getInstance()->get(StoreManagerInterface::class);
     }
 
     /**
@@ -57,18 +68,19 @@ class LowestPriceOptionsProvider implements LowestPriceOptionsProviderInterface
      */
     public function getProducts(ProductInterface $product)
     {
-        if (!isset($this->linkedProductMap[$product->getId()])) {
+        $key = $this->storeManager->getStore()->getId() . '-' . $product->getId();
+        if (!isset($this->linkedProductMap[$key])) {
             $productIds = $this->resource->getConnection()->fetchCol(
                 '(' . implode(') UNION (', $this->linkedProductSelectBuilder->build($product->getId())) . ')'
             );
 
-            $this->linkedProductMap[$product->getId()] = $this->collectionFactory->create()
+            $this->linkedProductMap[$key] = $this->collectionFactory->create()
                 ->addAttributeToSelect(
                     ['price', 'special_price', 'special_from_date', 'special_to_date', 'tax_class_id']
                 )
                 ->addIdFilter($productIds)
                 ->getItems();
         }
-        return $this->linkedProductMap[$product->getId()];
+        return $this->linkedProductMap[$key];
     }
 }

--- a/app/code/Magento/Paypal/Model/Report/Settlement.php
+++ b/app/code/Magento/Paypal/Model/Report/Settlement.php
@@ -369,7 +369,8 @@ class Settlement extends \Magento\Framework\Model\AbstractModel
                     // Section columns.
                     // In case ever the column order is changed, we will have the items recorded properly
                     // anyway. We have named, not numbered columns.
-                    for ($i = 1; $i < count($line); $i++) {
+                    $count = count($line);
+                    for ($i = 1; $i < $count; $i++) {
                         $sectionColumns[$line[$i]] = $i;
                     }
                     $flippedSectionColumns = array_flip($sectionColumns);

--- a/app/code/Magento/Review/view/frontend/web/js/process-reviews.js
+++ b/app/code/Magento/Review/view/frontend/web/js/process-reviews.js
@@ -50,15 +50,15 @@ define([
 
         $(function () {
             $('.product-info-main .reviews-actions a').click(function (event) {
-                var acnchor;
+                var anchor;
 
                 event.preventDefault();
-                acnchor = $(this).attr('href').replace(/^.*?(#|$)/, '');
+                anchor = $(this).attr('href').replace(/^.*?(#|$)/, '');
                 $('.product.data.items [data-role="content"]').each(function (index) { //eslint-disable-line
                     if (this.id == 'reviews') { //eslint-disable-line eqeqeq
                         $('.product.data.items').tabs('activate', index);
                         $('html, body').animate({
-                            scrollTop: $('#' + acnchor).offset().top - 50
+                            scrollTop: $('#' + anchor).offset().top - 50
                         }, 300);
                     }
                 });

--- a/app/code/Magento/Sales/Model/Order/Item.php
+++ b/app/code/Magento/Sales/Model/Order/Item.php
@@ -233,7 +233,7 @@ class Item extends AbstractModel implements OrderItemInterface
     public function getSimpleQtyToShip()
     {
         $qty = $this->getQtyOrdered() - $this->getQtyShipped() - $this->getQtyRefunded() - $this->getQtyCanceled();
-        return max($qty, 0);
+        return max(round($qty, 8), 0);
     }
 
     /**
@@ -248,7 +248,7 @@ class Item extends AbstractModel implements OrderItemInterface
         }
 
         $qty = $this->getQtyOrdered() - $this->getQtyInvoiced() - $this->getQtyCanceled();
-        return max($qty, 0);
+        return max(round($qty, 8), 0);
     }
 
     /**

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/ItemTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/ItemTest.php
@@ -235,4 +235,201 @@ class ItemTest extends \PHPUnit\Framework\TestCase
             ]
         ];
     }
+
+    /**
+     * Test different combinations of item qty setups
+     *
+     * @param array $options
+     * @param float $expectedResult
+     *
+     * @dataProvider getItemQtyVariants
+     */
+    public function testGetSimpleQtyToShip(array $options, $expectedResult)
+    {
+        $this->model->setData($options);
+        $this->assertSame($this->model->getSimpleQtyToShip(), $expectedResult['to_ship']);
+    }
+
+    /**
+     * Test different combinations of item qty setups
+     *
+     * @param array $options
+     * @param float $expectedResult
+     *
+     * @dataProvider getItemQtyVariants
+     */
+    public function testGetQtyToInvoice(array $options, $expectedResult)
+    {
+        $this->model->setData($options);
+        $this->assertSame($this->model->getQtyToInvoice(), $expectedResult['to_invoice']);
+    }
+
+    /**
+     * Provides different combinations of qty options for an item and the
+     * expected qtys pending shipment and invoice
+     *
+     * @return array
+     */
+    public function getItemQtyVariants()
+    {
+        return [
+            'empty_item' => [
+                'options' => [
+                    'qty_ordered' => 0,
+                    'qty_invoiced' => 0,
+                    'qty_refunded' => 0,
+                    'qty_shipped' => 0,
+                    'qty_canceled' => 0,
+                ],
+                'expectedResult' => [
+                    'to_ship' => 0.0,
+                    'to_invoice' => 0.0
+                ]
+            ],
+            'ordered_item' => [
+                'options' => [
+                    'qty_ordered' => 12,
+                    'qty_invoiced' => 0,
+                    'qty_refunded' => 0,
+                    'qty_shipped' => 0,
+                    'qty_canceled' => 0,
+                ],
+                'expectedResult' => [
+                    'to_ship' => 12.0,
+                    'to_invoice' => 12.0
+                ]
+            ],
+            'partially_invoiced' => [
+                'options' => [
+                    'qty_ordered' => 12,
+                    'qty_invoiced' => 4,
+                    'qty_refunded' => 0,
+                    'qty_shipped' => 0,
+                    'qty_canceled' => 0,
+                ],
+                'expectedResult' => [
+                    'to_ship' => 12.0,
+                    'to_invoice' => 8.0
+                ]
+            ],
+            'completely_invoiced' => [
+                'options' => [
+                    'qty_ordered' => 12,
+                    'qty_invoiced' => 12,
+                    'qty_refunded' => 0,
+                    'qty_shipped' => 0,
+                    'qty_canceled' => 0,
+                ],
+                'expectedResult' => [
+                    'to_ship' => 12.0,
+                    'to_invoice' => 0.0
+                ]
+            ],
+            'partially_invoiced_refunded' => [
+                'options' => [
+                    'qty_ordered' => 12,
+                    'qty_invoiced' => 5,
+                    'qty_refunded' => 5,
+                    'qty_shipped' => 0,
+                    'qty_canceled' => 0,
+                ],
+                'expectedResult' => [
+                    'to_ship' => 7.0,
+                    'to_invoice' => 7.0
+                ]
+            ],
+            'partially_refunded' => [
+                'options' => [
+                    'qty_ordered' => 12,
+                    'qty_invoiced' => 12,
+                    'qty_refunded' => 5,
+                    'qty_shipped' => 0,
+                    'qty_canceled' => 0,
+                ],
+                'expectedResult' => [
+                    'to_ship' => 7.0,
+                    'to_invoice' => 0.0
+                ]
+            ],
+            'partially_shipped' => [
+                'options' => [
+                    'qty_ordered' => 12,
+                    'qty_invoiced' => 0,
+                    'qty_refunded' => 0,
+                    'qty_shipped' => 4,
+                    'qty_canceled' => 0,
+                ],
+                'expectedResult' => [
+                    'to_ship' => 8.0,
+                    'to_invoice' => 12.0
+                ]
+            ],
+            'partially_refunded_partially_shipped' => [
+                'options' => [
+                    'qty_ordered' => 12,
+                    'qty_invoiced' => 12,
+                    'qty_refunded' => 5,
+                    'qty_shipped' => 4,
+                    'qty_canceled' => 0,
+                ],
+                'expectedResult' => [
+                    'to_ship' => 3.0,
+                    'to_invoice' => 0.0
+                ]
+            ],
+            'complete' => [
+                'options' => [
+                    'qty_ordered' => 12,
+                    'qty_invoiced' => 12,
+                    'qty_refunded' => 0,
+                    'qty_shipped' => 12,
+                    'qty_canceled' => 0,
+                ],
+                'expectedResult' => [
+                    'to_ship' => 0.0,
+                    'to_invoice' => 0.0
+                ]
+            ],
+            'canceled' => [
+                'options' => [
+                    'qty_ordered' => 12,
+                    'qty_invoiced' => 0,
+                    'qty_refunded' => 0,
+                    'qty_shipped' => 0,
+                    'qty_canceled' => 12,
+                ],
+                'expectedResult' => [
+                    'to_ship' => 0.0,
+                    'to_invoice' => 0.0
+                ]
+            ],
+            'completely_shipped_using_decimals' => [
+                'options' => [
+                    'qty_ordered' => 4.4,
+                    'qty_invoiced' => 0.4,
+                    'qty_refunded' => 0.4,
+                    'qty_shipped' => 4,
+                    'qty_canceled' => 0,
+                ],
+                'expectedResult' => [
+                    'to_ship' => 0.0,
+                    'to_invoice' => 4.0
+                ]
+            ],
+            'completely_invoiced_using_decimals' => [
+                'options' => [
+                    'qty_ordered' => 4.4,
+                    'qty_invoiced' => 4,
+                    'qty_refunded' => 0,
+                    'qty_shipped' => 4,
+                    'qty_canceled' => 0.4,
+                ],
+                'expectedResult' => [
+                    'to_ship' => 0.0,
+                    'to_invoice' => 0.0
+                ]
+            ]
+        ];
+    }
+
 }

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/ItemTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/ItemTest.php
@@ -275,161 +275,87 @@ class ItemTest extends \PHPUnit\Framework\TestCase
         return [
             'empty_item' => [
                 'options' => [
-                    'qty_ordered' => 0,
-                    'qty_invoiced' => 0,
-                    'qty_refunded' => 0,
-                    'qty_shipped' => 0,
-                    'qty_canceled' => 0,
+                    'qty_ordered' => 0, 'qty_invoiced' => 0, 'qty_refunded' => 0, 'qty_shipped' => 0,
+                    'qty_canceled' => 0
                 ],
-                'expectedResult' => [
-                    'to_ship' => 0.0,
-                    'to_invoice' => 0.0
-                ]
+                'expectedResult' => ['to_ship' => 0.0, 'to_invoice' => 0.0]
             ],
             'ordered_item' => [
                 'options' => [
-                    'qty_ordered' => 12,
-                    'qty_invoiced' => 0,
-                    'qty_refunded' => 0,
-                    'qty_shipped' => 0,
-                    'qty_canceled' => 0,
+                    'qty_ordered' => 12, 'qty_invoiced' => 0, 'qty_refunded' => 0, 'qty_shipped' => 0,
+                    'qty_canceled' => 0
                 ],
-                'expectedResult' => [
-                    'to_ship' => 12.0,
-                    'to_invoice' => 12.0
-                ]
+                'expectedResult' => ['to_ship' => 12.0, 'to_invoice' => 12.0]
             ],
             'partially_invoiced' => [
-                'options' => [
-                    'qty_ordered' => 12,
-                    'qty_invoiced' => 4,
-                    'qty_refunded' => 0,
-                    'qty_shipped' => 0,
+                'options' => ['qty_ordered' => 12, 'qty_invoiced' => 4, 'qty_refunded' => 0, 'qty_shipped' => 0,
                     'qty_canceled' => 0,
                 ],
-                'expectedResult' => [
-                    'to_ship' => 12.0,
-                    'to_invoice' => 8.0
-                ]
+                'expectedResult' => ['to_ship' => 12.0, 'to_invoice' => 8.0]
             ],
             'completely_invoiced' => [
                 'options' => [
-                    'qty_ordered' => 12,
-                    'qty_invoiced' => 12,
-                    'qty_refunded' => 0,
-                    'qty_shipped' => 0,
+                    'qty_ordered' => 12, 'qty_invoiced' => 12, 'qty_refunded' => 0, 'qty_shipped' => 0,
                     'qty_canceled' => 0,
                 ],
-                'expectedResult' => [
-                    'to_ship' => 12.0,
-                    'to_invoice' => 0.0
-                ]
+                'expectedResult' => ['to_ship' => 12.0, 'to_invoice' => 0.0]
             ],
             'partially_invoiced_refunded' => [
                 'options' => [
-                    'qty_ordered' => 12,
-                    'qty_invoiced' => 5,
-                    'qty_refunded' => 5,
-                    'qty_shipped' => 0,
+                    'qty_ordered' => 12, 'qty_invoiced' => 5, 'qty_refunded' => 5, 'qty_shipped' => 0,
                     'qty_canceled' => 0,
                 ],
-                'expectedResult' => [
-                    'to_ship' => 7.0,
-                    'to_invoice' => 7.0
-                ]
+                'expectedResult' => ['to_ship' => 7.0, 'to_invoice' => 7.0]
             ],
             'partially_refunded' => [
                 'options' => [
-                    'qty_ordered' => 12,
-                    'qty_invoiced' => 12,
-                    'qty_refunded' => 5,
-                    'qty_shipped' => 0,
+                    'qty_ordered' => 12, 'qty_invoiced' => 12, 'qty_refunded' => 5, 'qty_shipped' => 0,
                     'qty_canceled' => 0,
                 ],
-                'expectedResult' => [
-                    'to_ship' => 7.0,
-                    'to_invoice' => 0.0
-                ]
+                'expectedResult' => ['to_ship' => 7.0, 'to_invoice' => 0.0]
             ],
             'partially_shipped' => [
                 'options' => [
-                    'qty_ordered' => 12,
-                    'qty_invoiced' => 0,
-                    'qty_refunded' => 0,
-                    'qty_shipped' => 4,
-                    'qty_canceled' => 0,
+                    'qty_ordered' => 12, 'qty_invoiced' => 0, 'qty_refunded' => 0, 'qty_shipped' => 4,
+                    'qty_canceled' => 0
                 ],
-                'expectedResult' => [
-                    'to_ship' => 8.0,
-                    'to_invoice' => 12.0
-                ]
+                'expectedResult' => ['to_ship' => 8.0, 'to_invoice' => 12.0]
             ],
             'partially_refunded_partially_shipped' => [
                 'options' => [
-                    'qty_ordered' => 12,
-                    'qty_invoiced' => 12,
-                    'qty_refunded' => 5,
-                    'qty_shipped' => 4,
-                    'qty_canceled' => 0,
+                    'qty_ordered' => 12, 'qty_invoiced' => 12, 'qty_refunded' => 5, 'qty_shipped' => 4,
+                    'qty_canceled' => 0
                 ],
-                'expectedResult' => [
-                    'to_ship' => 3.0,
-                    'to_invoice' => 0.0
-                ]
+                'expectedResult' => ['to_ship' => 3.0, 'to_invoice' => 0.0]
             ],
             'complete' => [
                 'options' => [
-                    'qty_ordered' => 12,
-                    'qty_invoiced' => 12,
-                    'qty_refunded' => 0,
-                    'qty_shipped' => 12,
-                    'qty_canceled' => 0,
+                    'qty_ordered' => 12, 'qty_invoiced' => 12, 'qty_refunded' => 0, 'qty_shipped' => 12,
+                    'qty_canceled' => 0
                 ],
-                'expectedResult' => [
-                    'to_ship' => 0.0,
-                    'to_invoice' => 0.0
-                ]
+                'expectedResult' => ['to_ship' => 0.0, 'to_invoice' => 0.0]
             ],
             'canceled' => [
                 'options' => [
-                    'qty_ordered' => 12,
-                    'qty_invoiced' => 0,
-                    'qty_refunded' => 0,
-                    'qty_shipped' => 0,
-                    'qty_canceled' => 12,
+                    'qty_ordered' => 12, 'qty_invoiced' => 0, 'qty_refunded' => 0, 'qty_shipped' => 0,
+                    'qty_canceled' => 12
                 ],
-                'expectedResult' => [
-                    'to_ship' => 0.0,
-                    'to_invoice' => 0.0
-                ]
+                'expectedResult' => ['to_ship' => 0.0, 'to_invoice' => 0.0]
             ],
             'completely_shipped_using_decimals' => [
                 'options' => [
-                    'qty_ordered' => 4.4,
-                    'qty_invoiced' => 0.4,
-                    'qty_refunded' => 0.4,
-                    'qty_shipped' => 4,
+                    'qty_ordered' => 4.4, 'qty_invoiced' => 0.4, 'qty_refunded' => 0.4, 'qty_shipped' => 4,
                     'qty_canceled' => 0,
                 ],
-                'expectedResult' => [
-                    'to_ship' => 0.0,
-                    'to_invoice' => 4.0
-                ]
+                'expectedResult' => ['to_ship' => 0.0, 'to_invoice' => 4.0]
             ],
             'completely_invoiced_using_decimals' => [
                 'options' => [
-                    'qty_ordered' => 4.4,
-                    'qty_invoiced' => 4,
-                    'qty_refunded' => 0,
-                    'qty_shipped' => 4,
-                    'qty_canceled' => 0.4,
+                    'qty_ordered' => 4.4, 'qty_invoiced' => 4, 'qty_refunded' => 0, 'qty_shipped' => 4,
+                    'qty_canceled' => 0.4
                 ],
-                'expectedResult' => [
-                    'to_ship' => 0.0,
-                    'to_invoice' => 0.0
-                ]
+                'expectedResult' => ['to_ship' => 0.0, 'to_invoice' => 0.0]
             ]
         ];
     }
-
 }

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/ItemTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/ItemTest.php
@@ -244,23 +244,10 @@ class ItemTest extends \PHPUnit\Framework\TestCase
      *
      * @dataProvider getItemQtyVariants
      */
-    public function testGetSimpleQtyToShip(array $options, $expectedResult)
+    public function testGetSimpleQtyToMethods(array $options, $expectedResult)
     {
         $this->model->setData($options);
         $this->assertSame($this->model->getSimpleQtyToShip(), $expectedResult['to_ship']);
-    }
-
-    /**
-     * Test different combinations of item qty setups
-     *
-     * @param array $options
-     * @param float $expectedResult
-     *
-     * @dataProvider getItemQtyVariants
-     */
-    public function testGetQtyToInvoice(array $options, $expectedResult)
-    {
-        $this->model->setData($options);
         $this->assertSame($this->model->getQtyToInvoice(), $expectedResult['to_invoice']);
     }
 

--- a/app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote.php
+++ b/app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote.php
@@ -74,7 +74,7 @@ abstract class Quote extends \Magento\Backend\App\Action
     /**
      * Initiate action
      *
-     * @return this
+     * @return $this
      */
     protected function _initAction()
     {

--- a/app/code/Magento/Security/Model/AdminSessionInfo.php
+++ b/app/code/Magento/Security/Model/AdminSessionInfo.php
@@ -164,7 +164,7 @@ class AdminSessionInfo extends \Magento\Framework\Model\AbstractModel
      * Setter for isOtherSessionsTerminated
      *
      * @param bool $isOtherSessionsTerminated
-     * @return this
+     * @return $this
      * @since 100.1.0
      */
     public function setIsOtherSessionsTerminated($isOtherSessionsTerminated)

--- a/app/code/Magento/Usps/Model/Carrier.php
+++ b/app/code/Magento/Usps/Model/Carrier.php
@@ -2054,7 +2054,8 @@ class Carrier extends AbstractCarrierOnline implements \Magento\Shipping\Model\C
         if (preg_match('/[\\d\\w]{5}\\-[\\d\\w]{4}/', $zipString) != 0) {
             $zip = explode('-', $zipString);
         }
-        for ($i = 0; $i < count($zip); ++$i) {
+        $count = count($zip);
+        for ($i = 0; $i < $count; ++$i) {
             if (strlen($zip[$i]) == 5) {
                 $zip5 = $zip[$i];
             } elseif (strlen($zip[$i]) == 4) {

--- a/app/code/Magento/Webapi/Model/Rest/Swagger/Generator.php
+++ b/app/code/Magento/Webapi/Model/Rest/Swagger/Generator.php
@@ -749,7 +749,8 @@ class Generator extends AbstractSchemaGenerator
     private function convertPathParams($uri)
     {
         $parts = explode('/', $uri);
-        for ($i=0; $i < count($parts); $i++) {
+        $count = count($parts);
+        for ($i=0; $i < $count; $i++) {
             if (strpos($parts[$i], ':') === 0) {
                 $parts[$i] = '{' . substr($parts[$i], 1) . '}';
             }

--- a/app/code/Magento/Webapi/Model/Soap/Wsdl/ComplexTypeStrategy.php
+++ b/app/code/Magento/Webapi/Model/Soap/Wsdl/ComplexTypeStrategy.php
@@ -229,7 +229,8 @@ class ComplexTypeStrategy extends AbstractComplexTypeStrategy
         $this->_processElementType($elementType, $documentation, $appInfoNode);
 
         if (preg_match_all('/{([a-z]+):(.+)}/Ui', $documentation, $matches)) {
-            for ($i = 0; $i < count($matches[0]); $i++) {
+            $count = count($matches[0]);
+            for ($i = 0; $i < $count; $i++) {
                 $appinfoTag = $matches[0][$i];
                 $tagName = $matches[1][$i];
                 $tagValue = $matches[2][$i];

--- a/lib/internal/Magento/Framework/Locale/Config.php
+++ b/lib/internal/Magento/Framework/Locale/Config.php
@@ -102,6 +102,7 @@ class Config implements \Magento\Framework\Locale\ConfigInterface
         'lo_LA', /*Laotian*/
         'es_VE', /*Spanish (Venezuela)*/
         'en_IE', /*English (Ireland)*/
+        'es_BO', /*Spanish (Bolivia)*/
     ];
 
     /**


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13808
Backported pull request #13933

### Description
Some modules (e.g. Abandoned Cart, Algolia Search etc.) use store emulation functionality (`\Magento\Store\Model\App\Emulation::startEnvironmentEmulation`) to get product info (including configurable product price) for each store. Unfortunately `LowestPriceOptionsProvider` class save linked products collection at the `$linkedProductMap` property based on requested product id only. That is why configurable product price will be the same for other stores after first emulation.

### Manual testing scenarios
As explained in #13933
