### PR TITLE
[Forwardport] [Backport 2.2] Configurable product price options by store

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Pricing/Price/LowestPriceOptionsProvider.php
+++ b/app/code/Magento/ConfigurableProduct/Pricing/Price/LowestPriceOptionsProvider.php
@@ -9,6 +9,8 @@ use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\ResourceModel\Product\LinkedProductSelectBuilderInterface;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Retrieve list of products where each product contains lower price than others at least for one possible price type
@@ -31,7 +33,12 @@ class LowestPriceOptionsProvider implements LowestPriceOptionsProviderInterface
     private $collectionFactory;
 
     /**
-     * Key is product id. Value is array of prepared linked products
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * Key is product id and store id. Value is array of prepared linked products
      *
      * @var array
      */
@@ -41,15 +48,19 @@ class LowestPriceOptionsProvider implements LowestPriceOptionsProviderInterface
      * @param ResourceConnection $resourceConnection
      * @param LinkedProductSelectBuilderInterface $linkedProductSelectBuilder
      * @param CollectionFactory $collectionFactory
+     * @param StoreManagerInterface $storeManager
      */
     public function __construct(
         ResourceConnection $resourceConnection,
         LinkedProductSelectBuilderInterface $linkedProductSelectBuilder,
-        CollectionFactory $collectionFactory
+        CollectionFactory $collectionFactory,
+        StoreManagerInterface $storeManager = null
     ) {
         $this->resource = $resourceConnection;
         $this->linkedProductSelectBuilder = $linkedProductSelectBuilder;
         $this->collectionFactory = $collectionFactory;
+        $this->storeManager = $storeManager
+            ?: ObjectManager::getInstance()->get(StoreManagerInterface::class);
     }
 
     /**
@@ -57,18 +68,19 @@ class LowestPriceOptionsProvider implements LowestPriceOptionsProviderInterface
      */
     public function getProducts(ProductInterface $product)
     {
-        if (!isset($this->linkedProductMap[$product->getId()])) {
+        $key = $this->storeManager->getStore()->getId() . '-' . $product->getId();
+        if (!isset($this->linkedProductMap[$key])) {
             $productIds = $this->resource->getConnection()->fetchCol(
                 '(' . implode(') UNION (', $this->linkedProductSelectBuilder->build($product->getId())) . ')'
             );
 
-            $this->linkedProductMap[$product->getId()] = $this->collectionFactory->create()
+            $this->linkedProductMap[$key] = $this->collectionFactory->create()
                 ->addAttributeToSelect(
                     ['price', 'special_price', 'special_from_date', 'special_to_date', 'tax_class_id']
                 )
                 ->addIdFilter($productIds)
                 ->getItems();
         }
-        return $this->linkedProductMap[$product->getId()];
+        return $this->linkedProductMap[$key];
     }
 }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13808
Backported pull request #13933

### Description
Some modules (e.g. Abandoned Cart, Algolia Search etc.) use store emulation functionality (`\Magento\Store\Model\App\Emulation::startEnvironmentEmulation`) to get product info (including configurable product price) for each store. Unfortunately `LowestPriceOptionsProvider` class save linked products collection at the `$linkedProductMap` property based on requested product id only. That is why configurable product price will be the same for other stores after first emulation.

### Manual testing scenarios
As explained in #13933
