### PR TITLE
[Forwardport] Fix translate issue

### DIFF
--- a/lib/internal/Magento/Framework/Translate.php
+++ b/lib/internal/Magento/Framework/Translate.php
@@ -312,6 +312,9 @@ class Translate implements \Magento\Framework\TranslateInterface
     {
         foreach ($data as $key => $value) {
             if ($key === $value) {
+                if (isset($this->_data[$key])) {
+                    unset($this->_data[$key]);
+                }
                 continue;
             }
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13629
Fixes issue where translations are not allowed to be reset by a theme or db change to the original english text.

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
In Magento you have the ability to change translations in many ways, traditionally it would be through that the system prioritises translations as follows:

- The modules own translations
- Translate packs translations
- Theme translations
- Database (inline translations)

However if you have a translate pack translating a word, and you as a merchant or developer want to change it back in the theme or database translations, currently you can't because the _addData method currently validates if the original text and translation are the same. 

http://devbox.vaimo.test/ncg/pub/static/version1518511176/frontend/Vaimo/ncg/sv_SE/js-translation.js...

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Setup a store with a translate pack including a word used for translation in a JS file, as an example you can use "Close", which in your language pack should be set to something else. 
2. Setup a new theme with the language you picked and translate the text used in JS file. And set it to be the original value of this. So you set "Close":"Close"
3. Download the FE translate file js-translation.js from your theme using a URL like: pub/static/*Version*/frontend/*Vendor*/*Theme*/*Locale*/js-translation.js
4. You should now see that the value: "Close" is set to the language packs value, and not missing as you would expect so the string can go back to its default value.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
