### PR TITLE
[Forwardport] Specify the table when adding field to filter

### DIFF
--- a/app/code/Magento/Eav/Model/ResourceModel/Entity/Attribute/Option/Collection.php
+++ b/app/code/Magento/Eav/Model/ResourceModel/Entity/Attribute/Option/Collection.php
@@ -78,7 +78,7 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
      */
     public function setAttributeFilter($setId)
     {
-        return $this->addFieldToFilter('attribute_id', $setId);
+        return $this->addFieldToFilter('main_table.attribute_id', $setId);
     }
 
     /**


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14599
Specify the table when adding field to filter for the collection Eav/Model/ResourceModel/Entity/Attribute/Option/Collection.php

<!--- Provide a general summary of the Pull Request in the Title above -->
Resolve the problem https://github.com/magento/magento2/issues/14572

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#14572: Specify the table when adding field to filter for the collection Eav/Model/ResourceModel/Entity/Attribute/Option/Collection.php

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create a class with a property Magento\Eav\Model\ResourceModel\Entity\Attribute\Option\CollectionFactory
2. Create a collection with it and join tables like 'catalog_product_entity_int'
3. Get items of the collection.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
