### PR TITLE
[Forwardport] 6879 - Unable to change country of manufacture default label value

### DIFF
--- a/lib/web/mage/validation.js
+++ b/lib/web/mage/validation.js
@@ -195,8 +195,9 @@
         var empty = $(element).closest('table')
             .find('input.required-option:visible')
             .filter(function (i, el) {
-                if($(el).is('disabled'))
+                if ($(el).is('disabled')) {
                     return $.mage.isEmpty(el.value);
+                }
             })
             .length;
 

--- a/lib/web/mage/validation.js
+++ b/lib/web/mage/validation.js
@@ -195,7 +195,8 @@
         var empty = $(element).closest('table')
             .find('input.required-option:visible')
             .filter(function (i, el) {
-                return $.mage.isEmpty(el.value);
+                if($(el).is('disabled'))
+                    return $.mage.isEmpty(el.value);
             })
             .length;
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14319
### Description
This pull request fixes issue with not being able to save dropdown attributes which cannot be edited. I've added following change - while validating if the required value is empty, validation now also checks whether or not it's disabled. The issue occurred with "Country of Manufacture" attribute, which rows can't be edited. In general - it was occurring with all dropdown attributes that had disabled rows with at least one empty value in admin box.

### Fixed Issues
1. magento/magento2#6879: Unable to change country of manufacture default label value

### Manual testing scenarios
1. Navigate to product attributes in admin panel
2. Edit "Country of Manufacure" attribute
3. Save the attribute
4. Check if attribute has changes that are supposed to be saved.

### Contribution checklist
- [ ] Pull request has a meaningful description of its purpose
- [ ] All commits are accompanied by meaningful commit messages
- [ ] All new or changed code is covered with unit/integration tests (if applicable)
- [ ] All automated tests passed successfully (all builds on Travis CI are green)
