### PR TITLE
[Forwardport] Add default schedule config for sitemap_generate job

### DIFF
--- a/app/code/Magento/Sitemap/Model/Observer.php
+++ b/app/code/Magento/Sitemap/Model/Observer.php
@@ -18,11 +18,6 @@ class Observer
     const XML_PATH_GENERATION_ENABLED = 'sitemap/generate/enabled';
 
     /**
-     * Cronjob expression configuration
-     */
-    const XML_PATH_CRON_EXPR = 'crontab/default/jobs/generate_sitemaps/schedule/cron_expr';
-
-    /**
      * Error email template configuration
      */
     const XML_PATH_ERROR_TEMPLATE = 'sitemap/generate/error_email_template';
@@ -63,6 +58,11 @@ class Observer
      * @var \Magento\Framework\Translate\Inline\StateInterface
      */
     protected $inlineTranslation;
+
+    /**
+     * @var \Magento\Cron\Model\ScheduleFactory
+     */
+    private $scheduleFactory;
 
     /**
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig

--- a/app/code/Magento/Sitemap/Model/Observer.php
+++ b/app/code/Magento/Sitemap/Model/Observer.php
@@ -60,11 +60,6 @@ class Observer
     protected $inlineTranslation;
 
     /**
-     * @var \Magento\Cron\Model\ScheduleFactory
-     */
-    private $scheduleFactory;
-
-    /**
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      * @param \Magento\Sitemap\Model\ResourceModel\Sitemap\CollectionFactory $collectionFactory
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager

--- a/app/code/Magento/Sitemap/Model/Observer.php
+++ b/app/code/Magento/Sitemap/Model/Observer.php
@@ -18,6 +18,13 @@ class Observer
     const XML_PATH_GENERATION_ENABLED = 'sitemap/generate/enabled';
 
     /**
+     * Cronjob expression configuration
+     *
+     * @deprecated Use \Magento\Cron\Model\Config\Backend\Sitemap::CRON_STRING_PATH instead.
+     */
+    const XML_PATH_CRON_EXPR = 'crontab/default/jobs/generate_sitemaps/schedule/cron_expr';
+
+    /**
      * Error email template configuration
      */
     const XML_PATH_ERROR_TEMPLATE = 'sitemap/generate/error_email_template';

--- a/app/code/Magento/Sitemap/etc/config.xml
+++ b/app/code/Magento/Sitemap/etc/config.xml
@@ -42,5 +42,16 @@
                 </valid_paths>
             </file>
         </sitemap>
+        <crontab>
+            <default>
+                <jobs>
+                    <sitemap_generate>
+                        <schedule>
+                            <cron_expr>0 0 * * *</cron_expr>
+                        </schedule>
+                    </sitemap_generate>
+                </jobs>
+            </default>
+        </crontab>
     </default>
 </config>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14822
### Description
There was no default schedule configuration for `sitemap_generate` job, and I think this is causing confusion for [some people](https://community.magento.com/t5/Magento-2-x-Programming/How-sitemap-cronjob-works-in-Magento-2/td-p/66281).

Also I have removed a redundant constant in the sitemap observer. 

I think more work is required on sitemaps following this.

### Fixed Issues (if relevant)
1. magento/magento2#5768: Magento 2.0.7 XML sitemap is not generated by schedule (potentially, waiting feedback from creator)

### Manual testing scenarios
1. Create sitemap via admin
2. Do not sitemap generation schedule settings in Store > Configuration > Catalog > XML Sitemap > Generation Settings
3. Configure magento cron
4. Sitemap should be updated at midnight.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
